### PR TITLE
Add search functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ export default defineConfig({
   //...
   plugins: [
     simplerColorInput({
-      // Note: These are both optional
+      // Note: These are all optional
       defaultColorFormat: 'rgba',
       defaultColorList: [
         { label: 'Light', value: '#ffffff' },
@@ -56,6 +56,7 @@ export default defineConfig({
         { label: 'Accent', value: '#626754' },
         { label: 'Custom...', value: 'custom' },
       ],
+      enableSearch: true,
     })
   ],
 })
@@ -186,6 +187,22 @@ To allow custom color values, add an array item to `colorList` with its value se
       { label: 'Accent', value: '#626754' },
       { label: 'Custom...', value: 'custom' },
     ],
+  }
+}
+```
+
+### Enable Search
+
+To enable search in the color picker, set `enableSearch` to `true`.
+
+```js
+// ...fields...
+{
+  name: 'backgroundColor',
+  title: 'Background Color with Search',
+  type: 'simplerColor', // or textColor or highlightColor
+  options: {
+    enableSearch: true,
   }
 }
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {ColorFormatType} from './ColorInput'
 interface SimplerColorInputConfig {
   defaultColorList?: Array<{label: string; value: string}>
   defaultColorFormat?: ColorFormatType // defaults to 'hex'
+  enableSearch?: boolean // defaults to false
 }
 
 /**


### PR DESCRIPTION
This PR introduces an optional search field to the color picker, enhancing usability by allowing users to quickly find colors through text input. The feature is designed to be non-intrusive and is disabled by default. This is really helpful when you have a long list of color options.

This PR also fixes import of `@uiw/react-color`. Fixing https://github.com/cositehq/sanity-plugin-simpler-color-input/issues/4 

To enable the search field, add the following option to the plugin initialization or to a specific field:

```js
{
  enableSearch: true
}
```

Demo:

https://github.com/cositehq/sanity-plugin-simpler-color-input/assets/372430/98df9a3c-59f3-434d-a709-031668ce67e0

