### PR TITLE
fix: upgrade @uiw/react-color and import dist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@sanity/icons": "^2.3.1",
         "@sanity/incompatible-plugin": "^1.0.4",
         "@sanity/ui": "^1.3.3",
-        "@uiw/react-color": "^2.0.3",
+        "@uiw/react-color": "^2.0.8",
         "react-icons": "^4.11.0"
       },
       "devDependencies": {
@@ -6223,9 +6223,9 @@
       }
     },
     "node_modules/@uiw/color-convert": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@uiw/color-convert/-/color-convert-2.0.3.tgz",
-      "integrity": "sha512-lP/dnZzaiUDMrn3F+WYAG/TLhIanoy5A0HAPEO6Z/s3Jv5AI0nOM2bVOm0HI+vNiHZkVTkE1oGP0k+endEA+9A==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@uiw/color-convert/-/color-convert-2.0.8.tgz",
+      "integrity": "sha512-yh0Q91FwTNCl5rMpNSQSlpazMz65V6V0LMIyssHk0ris4af9xQi+t01snLP+Dbjbk4HaSy7b8AptTP3NudggdQ==",
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
       },
@@ -6234,29 +6234,30 @@
       }
     },
     "node_modules/@uiw/react-color": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@uiw/react-color/-/react-color-2.0.3.tgz",
-      "integrity": "sha512-W2zin6cxq1clQAJoUSbFbp07SkMKtYaoCOK1dLGE0OUM/oYMEw9eXTa8VbvVCY1e3plkXnA+/HgiCFBm6tVsQg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color/-/react-color-2.0.8.tgz",
+      "integrity": "sha512-C0glTJQC4kmq1pOYOQEENgUAFOu3AK/XQdRV/C2mRovLAH3GCkYq6zvv280F6zJcTZzdhhKKgXXyplJqoAzvdA==",
       "dependencies": {
-        "@uiw/color-convert": "2.0.3",
-        "@uiw/react-color-alpha": "2.0.3",
-        "@uiw/react-color-block": "2.0.3",
-        "@uiw/react-color-chrome": "2.0.3",
-        "@uiw/react-color-circle": "2.0.3",
-        "@uiw/react-color-colorful": "2.0.3",
-        "@uiw/react-color-compact": "2.0.3",
-        "@uiw/react-color-editable-input": "2.0.3",
-        "@uiw/react-color-editable-input-hsla": "2.0.3",
-        "@uiw/react-color-editable-input-rgba": "2.0.3",
-        "@uiw/react-color-github": "2.0.3",
-        "@uiw/react-color-hue": "2.0.3",
-        "@uiw/react-color-material": "2.0.3",
-        "@uiw/react-color-saturation": "2.0.3",
-        "@uiw/react-color-shade-slider": "2.0.3",
-        "@uiw/react-color-sketch": "2.0.3",
-        "@uiw/react-color-slider": "2.0.3",
-        "@uiw/react-color-swatch": "2.0.3",
-        "@uiw/react-color-wheel": "2.0.3"
+        "@uiw/color-convert": "2.0.8",
+        "@uiw/react-color-alpha": "2.0.8",
+        "@uiw/react-color-block": "2.0.8",
+        "@uiw/react-color-chrome": "2.0.8",
+        "@uiw/react-color-circle": "2.0.8",
+        "@uiw/react-color-colorful": "2.0.8",
+        "@uiw/react-color-compact": "2.0.8",
+        "@uiw/react-color-editable-input": "2.0.8",
+        "@uiw/react-color-editable-input-hsla": "2.0.8",
+        "@uiw/react-color-editable-input-rgba": "2.0.8",
+        "@uiw/react-color-github": "2.0.8",
+        "@uiw/react-color-hue": "2.0.8",
+        "@uiw/react-color-material": "2.0.8",
+        "@uiw/react-color-name": "2.0.8",
+        "@uiw/react-color-saturation": "2.0.8",
+        "@uiw/react-color-shade-slider": "2.0.8",
+        "@uiw/react-color-sketch": "2.0.8",
+        "@uiw/react-color-slider": "2.0.8",
+        "@uiw/react-color-swatch": "2.0.8",
+        "@uiw/react-color-wheel": "2.0.8"
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
@@ -6268,12 +6269,12 @@
       }
     },
     "node_modules/@uiw/react-color-alpha": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@uiw/react-color-alpha/-/react-color-alpha-2.0.3.tgz",
-      "integrity": "sha512-bTO0jMTT2fFZr8lGpDrOCbMSbidkgYMuCmyc6A8p6WfyCznKZvKG5WG9KukDOB2ReJUZKIaiR20CgUa6opS3Hw==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-alpha/-/react-color-alpha-2.0.8.tgz",
+      "integrity": "sha512-QppWrb7QBTIi0xZ6Q818tSi0LpZfkB323Q4F36a/vH4chzqOJAj6aCFM18d1CqjcLT4R1gnDhBSlW2dVD/4YoQ==",
       "dependencies": {
-        "@uiw/color-convert": "2.0.3",
-        "@uiw/react-drag-event-interactive": "2.0.3"
+        "@uiw/color-convert": "2.0.8",
+        "@uiw/react-drag-event-interactive": "2.0.8"
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
@@ -6285,13 +6286,13 @@
       }
     },
     "node_modules/@uiw/react-color-block": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@uiw/react-color-block/-/react-color-block-2.0.3.tgz",
-      "integrity": "sha512-KDl4PBtv8/IAQ/HeonxsFka+9ppBTjKBhI7U/j6oxqvVPWuvqOZSGlAtr9oIGZnEG14CXZPg4xNVLkZQkfJ8vg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-block/-/react-color-block-2.0.8.tgz",
+      "integrity": "sha512-n/Wynq5C9MKKcWMHnRJ/dRyV1Cuexj3GMzvjpriSc3foQmFdReu+ElnRUgx4HgBmehbkes3VD/ppHMMrqm/T+A==",
       "dependencies": {
-        "@uiw/color-convert": "2.0.3",
-        "@uiw/react-color-editable-input": "2.0.3",
-        "@uiw/react-color-swatch": "2.0.3"
+        "@uiw/color-convert": "2.0.8",
+        "@uiw/react-color-editable-input": "2.0.8",
+        "@uiw/react-color-swatch": "2.0.8"
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
@@ -6303,18 +6304,18 @@
       }
     },
     "node_modules/@uiw/react-color-chrome": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@uiw/react-color-chrome/-/react-color-chrome-2.0.3.tgz",
-      "integrity": "sha512-qT9mdTf1wc1zTAb5K2sAs4VtNM9GwcR36ZeCbrLYLRMpovu4ynsZBAn0hR4RYc1xJJsedRZtelWPInAKLvwyEA==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-chrome/-/react-color-chrome-2.0.8.tgz",
+      "integrity": "sha512-nHMQTk7sA3iRtj5S+XfkAX/WYkQMXsnbEVA0v0KjywLZn/L2PFJNCtTx3mebLHQQvDLeKsLKl5XBqWes6utokw==",
       "dependencies": {
-        "@uiw/color-convert": "2.0.3",
-        "@uiw/react-color-alpha": "2.0.3",
-        "@uiw/react-color-editable-input": "2.0.3",
-        "@uiw/react-color-editable-input-hsla": "2.0.3",
-        "@uiw/react-color-editable-input-rgba": "2.0.3",
-        "@uiw/react-color-github": "2.0.3",
-        "@uiw/react-color-hue": "2.0.3",
-        "@uiw/react-color-saturation": "2.0.3"
+        "@uiw/color-convert": "2.0.8",
+        "@uiw/react-color-alpha": "2.0.8",
+        "@uiw/react-color-editable-input": "2.0.8",
+        "@uiw/react-color-editable-input-hsla": "2.0.8",
+        "@uiw/react-color-editable-input-rgba": "2.0.8",
+        "@uiw/react-color-github": "2.0.8",
+        "@uiw/react-color-hue": "2.0.8",
+        "@uiw/react-color-saturation": "2.0.8"
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
@@ -6326,12 +6327,12 @@
       }
     },
     "node_modules/@uiw/react-color-circle": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@uiw/react-color-circle/-/react-color-circle-2.0.3.tgz",
-      "integrity": "sha512-IBMzGOSVQvN/x5dAFk2j1bkGzWX/nWz9kmbcdETRhIQtBcP1AmrQHaRL3E+GX7oTB6cRMg2W20baxHgj97NQIQ==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-circle/-/react-color-circle-2.0.8.tgz",
+      "integrity": "sha512-/wBpxRX8LPoWKAiMhqZc0Ghojd4P96NKXeiObJtuf5SjoReSMOm7Y8mUjs9nWwL5DD/hslB4LGacuXb1PM3+0Q==",
       "dependencies": {
-        "@uiw/color-convert": "2.0.3",
-        "@uiw/react-color-swatch": "2.0.3"
+        "@uiw/color-convert": "2.0.8",
+        "@uiw/react-color-swatch": "2.0.8"
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
@@ -6343,14 +6344,14 @@
       }
     },
     "node_modules/@uiw/react-color-colorful": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@uiw/react-color-colorful/-/react-color-colorful-2.0.3.tgz",
-      "integrity": "sha512-IjnvYyroW/Kmz1ICSwQ6HUpl7cs6Rkh2mVuFGvYd8FOxBjbQuAI/pfVi8I54rgkesn8uRVYlbvl4ROfAl3RrHw==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-colorful/-/react-color-colorful-2.0.8.tgz",
+      "integrity": "sha512-CqJrDqj1Yr/ewNSi0gTDnlVz0tG9uvSO90/zpQzZrqFNj7l2JNBf7gWXGvQKcG9SqXZIthsErZc9YZVb/ty50A==",
       "dependencies": {
-        "@uiw/color-convert": "2.0.3",
-        "@uiw/react-color-alpha": "2.0.3",
-        "@uiw/react-color-hue": "2.0.3",
-        "@uiw/react-color-saturation": "2.0.3"
+        "@uiw/color-convert": "2.0.8",
+        "@uiw/react-color-alpha": "2.0.8",
+        "@uiw/react-color-hue": "2.0.8",
+        "@uiw/react-color-saturation": "2.0.8"
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
@@ -6362,14 +6363,14 @@
       }
     },
     "node_modules/@uiw/react-color-compact": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@uiw/react-color-compact/-/react-color-compact-2.0.3.tgz",
-      "integrity": "sha512-xjPn46zuFZZ0RqEB8ZelSdtU0ySpp4Ekgw+Wu/W7ZZrUGBXypgFSbQqudggOq7ovhU+4qxGOGqrN4SGHqH36mg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-compact/-/react-color-compact-2.0.8.tgz",
+      "integrity": "sha512-AieHnIrfnHZ0q9rCmHN8Kwr67e5rdhy+mOhKW2sY+tE9QkQZ68AxuHAjSZ5x5nR0cvMVoITXaysP2qn1av8X7Q==",
       "dependencies": {
-        "@uiw/color-convert": "2.0.3",
-        "@uiw/react-color-editable-input": "2.0.3",
-        "@uiw/react-color-editable-input-rgba": "2.0.3",
-        "@uiw/react-color-swatch": "2.0.3"
+        "@uiw/color-convert": "2.0.8",
+        "@uiw/react-color-editable-input": "2.0.8",
+        "@uiw/react-color-editable-input-rgba": "2.0.8",
+        "@uiw/react-color-swatch": "2.0.8"
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
@@ -6381,9 +6382,9 @@
       }
     },
     "node_modules/@uiw/react-color-editable-input": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@uiw/react-color-editable-input/-/react-color-editable-input-2.0.3.tgz",
-      "integrity": "sha512-Zy+BuvtQ5c2XcSPN+zgVQ0gnz4fl+1YB1kpKnTYNyZptL2HXWPygwz2OdfNB/bVNRR34s5/4x3jD/zNQTBe60w==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-editable-input/-/react-color-editable-input-2.0.8.tgz",
+      "integrity": "sha512-WpehDwnIRTIOUYAnchSVjZu+TwJjA1vCiK+tMkgta/Nu2qI3bLLPTwKmIF1cQgcrEEKvfgaqOD3yP7BvjjKFJA==",
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
       },
@@ -6394,12 +6395,12 @@
       }
     },
     "node_modules/@uiw/react-color-editable-input-hsla": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@uiw/react-color-editable-input-hsla/-/react-color-editable-input-hsla-2.0.3.tgz",
-      "integrity": "sha512-RwFgPlOv/OjAtegCYIsoIFbWHhAEE44SMT/44zGlRfYq6PX3KvXjEfHpM7F7EFJHYuRfKFpQRhikc1kSkOeWVw==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-editable-input-hsla/-/react-color-editable-input-hsla-2.0.8.tgz",
+      "integrity": "sha512-UgVVXG21AF0ZhDE5SAcoBqFBCOOGxJhVBhl7pbZ9++MdGAw24MnwHnTLbce5cYqCWcD3/0689AvkQRr8X6H8DA==",
       "dependencies": {
-        "@uiw/color-convert": "2.0.3",
-        "@uiw/react-color-editable-input-rgba": "2.0.3"
+        "@uiw/color-convert": "2.0.8",
+        "@uiw/react-color-editable-input-rgba": "2.0.8"
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
@@ -6411,12 +6412,12 @@
       }
     },
     "node_modules/@uiw/react-color-editable-input-rgba": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@uiw/react-color-editable-input-rgba/-/react-color-editable-input-rgba-2.0.3.tgz",
-      "integrity": "sha512-ROz25EVr5F9XgNLG9p0RKMTgzg5ORh2RxMKC8Ch3vXrdTt4FL350Kq0N5KMHs7gyQAzcr4GQmuaCLlbEHHYAwA==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-editable-input-rgba/-/react-color-editable-input-rgba-2.0.8.tgz",
+      "integrity": "sha512-3bPmbyc1u6T++ap0pKl9w+x4+llDtLAuXY41NgNEUKhd63rMZjnVbVnFnzvIUDL92JRB5m+a+3Rr3n1TheeFew==",
       "dependencies": {
-        "@uiw/color-convert": "2.0.3",
-        "@uiw/react-color-editable-input": "2.0.3"
+        "@uiw/color-convert": "2.0.8",
+        "@uiw/react-color-editable-input": "2.0.8"
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
@@ -6428,12 +6429,12 @@
       }
     },
     "node_modules/@uiw/react-color-github": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@uiw/react-color-github/-/react-color-github-2.0.3.tgz",
-      "integrity": "sha512-pMv6lc76UmReAKtKlNSyHoFTpeeyD4z2Vr51uiiQqHS09wXisyPRX0KvpvWnGtBXXci9dkOx8kpohwhiKGpPHw==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-github/-/react-color-github-2.0.8.tgz",
+      "integrity": "sha512-Zuuy02ZIQHVBMpb0xvTcPG1VnzOu4Efr1ANbMoLsL2ahhbK5vg5JQfeLKO5gWSHgS4hR2f8yqJ2r+8ThqW4zQQ==",
       "dependencies": {
-        "@uiw/color-convert": "2.0.3",
-        "@uiw/react-color-swatch": "2.0.3"
+        "@uiw/color-convert": "2.0.8",
+        "@uiw/react-color-swatch": "2.0.8"
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
@@ -6445,12 +6446,12 @@
       }
     },
     "node_modules/@uiw/react-color-hue": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@uiw/react-color-hue/-/react-color-hue-2.0.3.tgz",
-      "integrity": "sha512-Bi9/JkLH6FSxULC52y7kjLlunkRbL6TRuAzm5+BBs/4tSf+VL8Xp5Dr2gCPJG1vuA4ohDx9vl3P5QO4Rk9h8wQ==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-hue/-/react-color-hue-2.0.8.tgz",
+      "integrity": "sha512-h3EKzc87/leSq94dBchAqN+0liPQZismqjlGOM2LsZadGqgn9pO4+3+SlO4kD5IdQIybCRXmK3zVUVGDdxOIYg==",
       "dependencies": {
-        "@uiw/color-convert": "2.0.3",
-        "@uiw/react-color-alpha": "2.0.3"
+        "@uiw/color-convert": "2.0.8",
+        "@uiw/react-color-alpha": "2.0.8"
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
@@ -6462,13 +6463,13 @@
       }
     },
     "node_modules/@uiw/react-color-material": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@uiw/react-color-material/-/react-color-material-2.0.3.tgz",
-      "integrity": "sha512-xgJ76LvF+LM+8emUby1EwcIwdtTLlA0JpQePwZi78J1DY3gQs9tTWHCaAkqZoprHiNlzXTHtqi8Wg/i0MIPLPw==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-material/-/react-color-material-2.0.8.tgz",
+      "integrity": "sha512-ONd7mxPWp0nKeJfXU51CPnra/cDtLJKmnL1yfFeCvdm1zgd5fn1pAXOd68k1CqvDNgaDY2z0J0oTeexyENNMeA==",
       "dependencies": {
-        "@uiw/color-convert": "2.0.3",
-        "@uiw/react-color-editable-input": "2.0.3",
-        "@uiw/react-color-editable-input-rgba": "2.0.3"
+        "@uiw/color-convert": "2.0.8",
+        "@uiw/react-color-editable-input": "2.0.8",
+        "@uiw/react-color-editable-input-rgba": "2.0.8"
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
@@ -6479,13 +6480,28 @@
         "react-dom": ">=16.9.0"
       }
     },
-    "node_modules/@uiw/react-color-saturation": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@uiw/react-color-saturation/-/react-color-saturation-2.0.3.tgz",
-      "integrity": "sha512-+AZM3WemWv7w/uRGmSY5lXWdSJoKKysKMW+C7/qkWNQmN/WjG6YmC4ZtcEqPr7BbWFXSS2DJTn15fNBvxCFKDg==",
+    "node_modules/@uiw/react-color-name": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-name/-/react-color-name-2.0.8.tgz",
+      "integrity": "sha512-OGZoARo7B6stqVkmMAcNUbECnnp6CevbrZCDaXSAjLwNNxSM9ZiuEoWeVWi/ZhOgv1KHHlCjYC+UOr4zI6EtQQ==",
       "dependencies": {
-        "@uiw/color-convert": "2.0.3",
-        "@uiw/react-drag-event-interactive": "2.0.3"
+        "colors-named": "^1.0.1",
+        "colors-named-hex": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0"
+      }
+    },
+    "node_modules/@uiw/react-color-saturation": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-saturation/-/react-color-saturation-2.0.8.tgz",
+      "integrity": "sha512-cBZ5Al4YrHOYTcWiRQzjYiT5Llgv7pnFEZPy07dQ5NSL+FlzQmDfjVmQynXUqYG3IqQrx0Md4jJLLhhLP9Q5MQ==",
+      "dependencies": {
+        "@uiw/color-convert": "2.0.8",
+        "@uiw/react-drag-event-interactive": "2.0.8"
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
@@ -6497,12 +6513,12 @@
       }
     },
     "node_modules/@uiw/react-color-shade-slider": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@uiw/react-color-shade-slider/-/react-color-shade-slider-2.0.3.tgz",
-      "integrity": "sha512-TTxNkzExgurWKklC90+D1HbtRMD37wKoK9kOLOvLynEm3r5SgcifjvZLNIBC8CUTbQutazAKl1IXgQCST09ang==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-shade-slider/-/react-color-shade-slider-2.0.8.tgz",
+      "integrity": "sha512-fVfmHTpPU5Mn2LCB1j6Wjw0AqszGuCthyH3U9GKpjQNrOSGe0G5tI6zMcqzut5wF3ovu4GSTAmA7bJxm+Rbrqw==",
       "dependencies": {
-        "@uiw/color-convert": "2.0.3",
-        "@uiw/react-color-alpha": "2.0.3"
+        "@uiw/color-convert": "2.0.8",
+        "@uiw/react-color-alpha": "2.0.8"
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
@@ -6514,17 +6530,17 @@
       }
     },
     "node_modules/@uiw/react-color-sketch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@uiw/react-color-sketch/-/react-color-sketch-2.0.3.tgz",
-      "integrity": "sha512-OS7nD7DlsYhtQJrSQOwM2kXcLrpqYzbLcY6dy55odmgMPx1ixbhhgXfDp8zAPOT5+guPAOdfy4PV4fpUGGYiSg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-sketch/-/react-color-sketch-2.0.8.tgz",
+      "integrity": "sha512-4b4mDMJHTsxuab75bmcH5OvDOvcam8irkYapIbcVLJzrBurWiuxflMdmsht37hKegPOsRp6m0NONfEGcUtg1fQ==",
       "dependencies": {
-        "@uiw/color-convert": "2.0.3",
-        "@uiw/react-color-alpha": "2.0.3",
-        "@uiw/react-color-editable-input": "2.0.3",
-        "@uiw/react-color-editable-input-rgba": "2.0.3",
-        "@uiw/react-color-hue": "2.0.3",
-        "@uiw/react-color-saturation": "2.0.3",
-        "@uiw/react-color-swatch": "2.0.3"
+        "@uiw/color-convert": "2.0.8",
+        "@uiw/react-color-alpha": "2.0.8",
+        "@uiw/react-color-editable-input": "2.0.8",
+        "@uiw/react-color-editable-input-rgba": "2.0.8",
+        "@uiw/react-color-hue": "2.0.8",
+        "@uiw/react-color-saturation": "2.0.8",
+        "@uiw/react-color-swatch": "2.0.8"
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
@@ -6536,12 +6552,12 @@
       }
     },
     "node_modules/@uiw/react-color-slider": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@uiw/react-color-slider/-/react-color-slider-2.0.3.tgz",
-      "integrity": "sha512-ejIVLFVwNYGlGqesJOwOgw1DYBljeHB2pznJCQI/YZyVVq9pM/fjDCjpxFQ/BgU7k/Ezs/UW90QHIxOy+tct4g==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-slider/-/react-color-slider-2.0.8.tgz",
+      "integrity": "sha512-CnxbtTggEWDtt326J0E/XO6+7IV1QHQO51SDfgeU9Um7A7MmZ3XJ+1iC6hBwYhaFxMIkmVSTnZsz7+YUkK24rg==",
       "dependencies": {
-        "@uiw/color-convert": "2.0.3",
-        "@uiw/react-color-alpha": "2.0.3"
+        "@uiw/color-convert": "2.0.8",
+        "@uiw/react-color-alpha": "2.0.8"
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
@@ -6553,11 +6569,11 @@
       }
     },
     "node_modules/@uiw/react-color-swatch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@uiw/react-color-swatch/-/react-color-swatch-2.0.3.tgz",
-      "integrity": "sha512-xKUASrSB4wPQ+kmMV1Yr1gQ9BZvMzkdotr9o+CYFGvZNSLclEur0cIhu5RkBhZ6PGP6Vd54mod43amY/a905lw==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-swatch/-/react-color-swatch-2.0.8.tgz",
+      "integrity": "sha512-ZURW9tsTNv8ea5TJqYvN2gqoljrhtjPpzs4UC9C7vfI6JvDdjAzIyMwRwRVCftekOtvLvdGZzXYXbGxPF4BvTQ==",
       "dependencies": {
-        "@uiw/color-convert": "2.0.3"
+        "@uiw/color-convert": "2.0.8"
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
@@ -6569,12 +6585,12 @@
       }
     },
     "node_modules/@uiw/react-color-wheel": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@uiw/react-color-wheel/-/react-color-wheel-2.0.3.tgz",
-      "integrity": "sha512-IEQ75777ZNvaA2dunTc/zD7OmcwbTjKeLGZ7Mo8ID+Em0rLF7SCC+9g2pF8G468MAc9HwyfRjv8K6Z69PWUyNg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-wheel/-/react-color-wheel-2.0.8.tgz",
+      "integrity": "sha512-tDoLK87twaa/0Y9vyRzodti25kQjznvHvATpsyO1mhI7v92qSFHJd2UJlk+Hfxin4m3L491KHlZcS5aKXcaE+g==",
       "dependencies": {
-        "@uiw/color-convert": "2.0.3",
-        "@uiw/react-drag-event-interactive": "2.0.3"
+        "@uiw/color-convert": "2.0.8",
+        "@uiw/react-drag-event-interactive": "2.0.8"
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
@@ -6586,9 +6602,9 @@
       }
     },
     "node_modules/@uiw/react-drag-event-interactive": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@uiw/react-drag-event-interactive/-/react-drag-event-interactive-2.0.3.tgz",
-      "integrity": "sha512-r9VQbvpk2z0ux3GenmT5K4BVQqT91eBSDQjYuR43Ya0kJaD2yJPuPe8JqvKTFR3/C9kldolJoWbxl0mbuu1X0w==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-drag-event-interactive/-/react-drag-event-interactive-2.0.8.tgz",
+      "integrity": "sha512-Z8awDfUV7970Q6GfJmx6x7fx5KeHn6RPinQVRYRAnKS7QP6XgQOIvVn8bYKe5vd4vQeBbzIVYYySjYRWjA5heA==",
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
       },
@@ -7822,6 +7838,28 @@
       "dev": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/colors-named": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/colors-named/-/colors-named-1.0.2.tgz",
+      "integrity": "sha512-2ANq2r393PV9njYUD66UdfBcxR1slMqRA3QRTWgCx49JoCJ+kOhyfbQYxKJbPZQIhZUcNjVOs5AlyY1WwXec3w==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/colors-named-hex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/colors-named-hex/-/colors-named-hex-1.0.2.tgz",
+      "integrity": "sha512-k6kq1e1pUCQvSVwIaGFq2l0LrkAPQZWyeuZn1Z8nOiYSEZiKoFj4qx690h2Kd34DFl9Me0gKS6MUwAMBJj8nuA==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
       }
     },
     "node_modules/combined-stream": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@sanity/icons": "^2.3.1",
     "@sanity/incompatible-plugin": "^1.0.4",
     "@sanity/ui": "^1.3.3",
-    "@uiw/react-color": "^2.0.3",
+    "@uiw/react-color": "^2.0.8",
     "react-icons": "^4.11.0"
   },
   "devDependencies": {
@@ -85,9 +85,9 @@
     "typescript": "^5.0.4"
   },
   "peerDependencies": {
+    "@sanity/ui": "^1.0 || ^2.0.0-beta",
     "react": "^18",
-    "sanity": "^3",
-    "@sanity/ui": "^1.0 || ^2.0.0-beta"
+    "sanity": "^3"
   },
   "engines": {
     "node": ">=14"

--- a/src/ColorInput.tsx
+++ b/src/ColorInput.tsx
@@ -14,14 +14,7 @@ import {
 import React, {useCallback, useEffect, useRef, useState} from 'react'
 import {ObjectInputProps, ObjectOptions, ObjectSchemaType, set, unset} from 'sanity'
 import {CloseIcon} from '@sanity/icons'
-// https://github.com/uiwjs/react-color/issues/104
-import {
-  Chrome,
-  ColorResult,
-  HsvaColor,
-  hslStringToHsva,
-  rgbStringToHsva,
-} from '@uiw/react-color/src/index'
+import {Chrome, ColorResult, HsvaColor, hslStringToHsva, rgbStringToHsva} from '@uiw/react-color'
 
 export interface SimplerColorType {
   label: string


### PR DESCRIPTION
Fixes #6.

The upstream issue (https://github.com/uiwjs/react-color/issues/104) with the `@uiw/react-color` package has been fixed.

It's now possible to import `@uiw/react-color` in a CommonJS environment without issue.

Updating the importing to the proper dist import in this package, fixes #6, and allows this plugin to work in Sanity CLI environments, which are not capable of building from source.